### PR TITLE
Rename `ZipFileReader` function to `zip_open_filereader`

### DIFF
--- a/src/ZipArchives.jl
+++ b/src/ZipArchives.jl
@@ -9,6 +9,7 @@ include("types.jl")
 
 include("reader.jl")
 export ZipFileReader
+export zip_open_filereader
 export ZipBufferReader
 
 export zip_crc32

--- a/src/reader.jl
+++ b/src/reader.jl
@@ -406,9 +406,8 @@ function parse_central_directory_headers!(central_dir_buffer::Vector{UInt8}, num
 end
 
 """
-    struct ZipFileReader
-    ZipFileReader(filename::AbstractString)
-    ZipFileReader(f::Function, filename::AbstractString)
+    zip_open_filereader(filename::AbstractString)::ZipFileReader
+    zip_open_filereader(f::Function, filename::AbstractString)
 
 Create a reader for a zip archive in a file at path `filename`.
 
@@ -426,18 +425,21 @@ Entries are indexed from `1:zip_nentries(r)`
 1. `zip_name(r::ZipFileReader, i::Integer)::String`
 1. `zip_uncompressed_size(r::ZipFileReader, i::Integer)::UInt64`
 
-`zip_test_entry(r::ZipFileReader, i::Integer)::Nothing` checks if an entry is valid and has a good checksum.
+`zip_test_entry(r::ZipFileReader, i::Integer)::Nothing` 
+checks if an entry is valid and has a good checksum.
 
-Reading an entry doesn't error if the checksum is bad, so use `zip_test_entry` if you are worried about data corruption.
+Reading an entry doesn't error if the checksum is bad, so use `zip_test_entry` 
+if you are worried about data corruption.
 
 `zip_openentry` and `zip_readentry` can be used to read data from an entry.
 
 To fully close the file, close all opened entries and the parent `ZipFileReader` object.
 
-This will happen automatically if the do block method is used
-for both the `ZipFileReader` constructor and `zip_openentry`
+This will happen automatically if the do block method 
+is used for `zip_open_filereader` and `zip_openentry`.
 
-After closing the returned `ZipFileReader`, any opened entries will remain opened and are still readable.
+After closing the returned `ZipFileReader`, any opened entries 
+will remain opened and are still readable.
 
 # Multi threading
 
@@ -445,7 +447,7 @@ The returned `ZipFileReader` object can safely be used from multiple threads;
 however, the objects returned by `zip_openentry` 
 should only be accessed by one thread at a time.
 """
-function ZipFileReader(filename::AbstractString)
+function zip_open_filereader(filename::AbstractString)::ZipFileReader
     io_lock = ReentrantLock()
     # I'm not sure if the lock is needed in the constructor.
     io = open(filename; lock=false)
@@ -476,9 +478,8 @@ function ZipFileReader(filename::AbstractString)
         rethrow()
     end
 end
-
-function ZipFileReader(f::Function, filename::AbstractString)
-    r = ZipFileReader(filename)
+function zip_open_filereader(f::Function, filename::AbstractString)
+    r = zip_open_filereader(filename)
     try
         f(r)
     finally
@@ -487,7 +488,7 @@ function ZipFileReader(f::Function, filename::AbstractString)
 end
 
 function Base.show(io::IO, r::ZipFileReader)
-    print(io, "ZipArchives.ZipFileReader(")
+    print(io, "ZipArchives.zip_open_filereader(")
     print(io, repr(r._name))
     print(io, ")")
 end

--- a/src/types.jl
+++ b/src/types.jl
@@ -39,6 +39,11 @@ struct EntryInfo
     comment::StringView{typeof(empty_buffer)}
 end
 
+"""
+    struct ZipFileReader
+
+Represents a zip archive file reader returned by [`zip_open_filereader`](@ref) 
+"""
 struct ZipFileReader
     entries::Vector{EntryInfo}
     central_dir_buffer::Vector{UInt8}

--- a/test/test_big_zips.jl
+++ b/test/test_big_zips.jl
@@ -9,7 +9,7 @@ using ZipArchives
             zip_writefile(w,"$i",codeunits("$(-i)"))
         end
     end
-    ZipFileReader(filename) do r
+    zip_open_filereader(filename) do r
         @test zip_nentries(r) == N
         for i in 1:N
             @test zip_name(r, i) == "$(i)"
@@ -33,7 +33,7 @@ end
             write(w, x)
         end
     end
-    ZipFileReader(filename) do r
+    zip_open_filereader(filename) do r
         @test zip_nentries(r) == 1
         zip_test_entry(r, 1)
     end
@@ -52,7 +52,7 @@ end
             zip_writefile(w,"$i", x)
         end
     end
-    ZipFileReader(filename) do r
+    zip_open_filereader(filename) do r
         @test zip_nentries(r) == 2^13
         for i in 1:2^13
             @test zip_name(r, i) == "$(i)"
@@ -70,7 +70,7 @@ end
             zip_writefile(w,"$i", x)
         end
     end
-    ZipFileReader(filename) do r
+    zip_open_filereader(filename) do r
         @test zip_nentries(r) == 2^16
         for i in 1:2^16
             @test zip_name(r, i) == "$(i)"

--- a/test/test_reader.jl
+++ b/test/test_reader.jl
@@ -109,8 +109,8 @@ end
     cp(invalid_file, filename)
     data = read(filename)
     @test_throws ArgumentError ZipBufferReader(data)
-    @test_throws ArgumentError r = ZipFileReader(filename)
-    # ZipFileReader will close the file if it has an error while parsing.
+    @test_throws ArgumentError r = zip_open_filereader(filename)
+    # zip_open_filereader will close the file if it has an error while parsing.
     # this will let the file be removed afterwards on windows.
     rm(filename)
 end
@@ -136,7 +136,7 @@ end
     @test_throws ArgumentError("invalid compression method: 14. Only Store and Deflate supported for now") zip_openentry(r, 1)
     @test zip_iscompressed(r, 1)
     @test zip_names(r) == ["lzma_data"]
-    ZipFileReader(filename) do r
+    zip_open_filereader(filename) do r
         @test_throws ArgumentError("invalid compression method: 14. Only Store and Deflate supported for now") zip_test_entry(r, 1)
         @test_throws ArgumentError("invalid compression method: 14. Only Store and Deflate supported for now") zip_openentry(r, 1)
         @test zip_iscompressed(r, 1)
@@ -166,7 +166,7 @@ end
     ref_file = testdata*"zip64.zip"
     filename = tempname()
     cp(ref_file, filename)
-    r = ZipFileReader(filename)
+    r = zip_open_filereader(filename)
     io1 = zip_openentry(r, 1)
     close(r)
     # data can still be read after `r` is closed
@@ -188,7 +188,7 @@ end
         zip_writefile(w, "test.txt", b"This small file is in STORE format.\n")
     end
 
-    r = ZipFileReader(filename)
+    r = zip_open_filereader(filename)
     io = zip_openentry(r, 1)
     close(r)
     @test !zip_iscompressed(r, 1)
@@ -237,7 +237,7 @@ end
 end
 
 function rewrite_zip(old::AbstractString, new::AbstractString)
-    ZipFileReader(old) do r
+    zip_open_filereader(old) do r
         ZipWriter(new) do w
             for i in 1:zip_nentries(r)
                 name = zip_name(r, i)

--- a/test/test_simple-usage.jl
+++ b/test/test_simple-usage.jl
@@ -36,9 +36,9 @@ using Test
         write(w, "I am data inside test2.txt in the zip file")
     end
 
-    # Read a zip file with `ZipFileReader`
-    ZipFileReader(filename) do r
-        @test repr(r) == "ZipArchives.ZipFileReader($(repr(filename)))"
+    # Read a zip file with `zip_open_filereader`
+    zip_open_filereader(filename) do r
+        @test repr(r) == "ZipArchives.zip_open_filereader($(repr(filename)))"
         zip_nentries(r) == 3
         @test zip_names(r) == ["test/test1.txt", "test/empty.txt", "test/test2.txt"]
         @test zip_name(r, 3) == "test/test2.txt"

--- a/test/test_writer.jl
+++ b/test/test_writer.jl
@@ -91,7 +91,7 @@ include("external_unzippers.jl")
             unzipper(zippath, tmpout)
             # Read zippath with ZipFileReader
             # Check file names and data match
-            ZipFileReader(zippath) do dir
+            zip_open_filereader(zippath) do dir
                 for i in 1:zip_nentries(dir)
                     local name = zip_name(dir, i)
                     local extracted_path = joinpath(tmpout, name)
@@ -148,7 +148,7 @@ end
         zip_commitfile(w)
         @test zip_nentries(w) == 1
         close(w)
-        ZipFileReader(filename) do r
+        zip_open_filereader(filename) do r
             @test zip_names(r) == ["good_file"]
             zip_openentry(r, 1) do file
                 @test read(file, String) == "sqrt(1.0): $(sqrt(1.0))"
@@ -241,7 +241,7 @@ end
             write(w, "inner4 text")
             @test_throws ArgumentError zip_commitfile(w)
         end
-        ZipFileReader(filename) do r
+        zip_open_filereader(filename) do r
             @test zip_names(r) == ["inner2.txt"]
             zip_openentry(r, 1) do entryio
                 @test read(entryio, String) == "inner2 text"


### PR DESCRIPTION
The `ZipFileReader` function didn't always return a `ZipFileReader` if called with the do block method.

However, because they are constructors, they should always return a `ZipFileReader`.

Therefore, I changed the name of those functions to `zip_open_filereader`

This is a breaking change.