### PR TITLE
Utility functions and breaking change to compression options

### DIFF
--- a/src/ZipArchives.jl
+++ b/src/ZipArchives.jl
@@ -24,6 +24,7 @@ export zip_stored_crc32
 export zip_definitely_utf8
 export zip_isdir
 export zip_isexecutablefile
+export zip_findlast_entry
 
 export zip_test_entry
 export zip_openentry

--- a/src/high-level.jl
+++ b/src/high-level.jl
@@ -48,7 +48,7 @@
 #         zip_newfile(w, stuff_name;
 #             # Note, on windows this tends to make everything executable.
 #             executable = Sys.isexecutable(stuff_path),
-#             compression_method = ZipArchives.Deflate,
+#             compress = true,
 #         )
 #         open(stuff_path) do from
 #             write(w, from)

--- a/src/reader.jl
+++ b/src/reader.jl
@@ -66,7 +66,37 @@ function zip_definitely_utf8(x::HasEntries, i::Integer)::Bool
     )
 end
 
+"""
+    zip_isdir(x::HasEntries, i::Integer)::Bool
+
+Return if entry `i` is a directory.
+"""
 zip_isdir(x::HasEntries, i::Integer)::Bool = endswith(x.entries[i].name, "/")
+
+"""
+    zip_isdir(x::HasEntries, s::AbstractString)::Bool
+
+Return if any entry has a relative path starting with `s`.
+"""
+function zip_isdir(x::HasEntries, s::AbstractString)::Bool
+    if !endswith(s,"/")
+        s *= "/"
+    end
+    any(x.entries) do e
+        startswith(e.name, s)
+    end
+end
+
+"""
+    zip_findlast_entry(x::HasEntries, s::AbstractString)::Union{Nothing, Int}
+
+Return the index of the last entry with name `s` or `nothing` if not found.
+"""
+function zip_findlast_entry(x::HasEntries, s::AbstractString)::Union{Nothing, Int}
+    findlast(x.entries) do e
+        e.name==s
+    end
+end
 
 function zip_isexecutablefile(x::HasEntries, i::Integer)::Bool
     entry = x.entries[i]
@@ -103,16 +133,49 @@ function zip_test_entry(r::ZipReader, i::Integer)::Nothing
     nothing
 end
 
-"""
-    zip_readentry(r, i::Integer, args...; kwargs...)
 
-Read the contents of entry `i` in `r`. 
+"""
+    zip_openentry(r::ZipReader, i::Union{AbstractString, Integer})
+    zip_openentry(f::Function, r::ZipReader, i::Union{AbstractString, Integer})
+
+Open entry `i` from `r` as a readable IO.
+
+Make sure to close this when done reading, 
+if not using the do block method.
+
+The stream returned by this function
+should only be accessed by one thread at a time.
+
+If `i` is a string open the last entry with the exact matching name.
+"""
+function zip_openentry(f::Function, r::ZipReader, i::Union{AbstractString, Integer})
+    io = zip_openentry(r, i)
+    try
+        f(io)
+    finally
+        close(io)
+    end
+end
+zip_openentry(r::ZipReader, i::Integer) = zip_openentry(r, Int(i))
+function zip_openentry(r::ZipReader, s::AbstractString)
+    i = zip_findlast_entry(r, s)
+    isnothing(i) && throw(ArgumentError("entry with name $(repr(s)) not found"))
+    zip_openentry(r, i)
+end
+
+
+
+"""
+    zip_readentry(r, i::Union{AbstractString, Integer}, args...; kwargs...)
+
+Read the contents of entry `i` in `r`.
+
+If `i` is a string read the last entry with the exact matching name.
 
 `args...; kwargs...` are passed on to `read`
-after the entry `i` in zip reader `r` is opened.
+after the entry `i` in zip reader `r` is opened with [`zip_openentry`](@ref)
 """
-zip_readentry(r::ZipReader, i::Integer, args...; kwargs...) = zip_openentry(io -> read(io, args...; kwargs...), r, i)
-
+zip_readentry(r::ZipReader, i::Union{AbstractString, Integer}, args...; kwargs...) = zip_openentry(io -> read(io, args...; kwargs...), r, i)
 
 
 
@@ -518,20 +581,7 @@ function validate_entry(entry::EntryInfo, fsize::Int64)
     nothing
 end
 
-
-"""
-    zip_openentry(r::ZipReader, i::Integer)
-    zip_openentry(f::Function, r::ZipReader, i::Integer)
-
-Open entry `i` from `r` as a readable IO.
-
-Make sure to close this when done reading, 
-if not using the do block method.
-
-The stream returned by this function
-should only be accessed by one thread at a time.
-"""
-function zip_openentry(r::ZipFileReader, i::Integer)::TranscodingStream
+function zip_openentry(r::ZipFileReader, i::Int)::TranscodingStream
     entry::EntryInfo = r.entries[i]
     validate_entry(entry, r._fsize)
     lock(r._lock) do
@@ -579,15 +629,6 @@ function zip_openentry(r::ZipFileReader, i::Integer)::TranscodingStream
     catch
         close(base_io)
         rethrow()
-    end
-end
-
-function zip_openentry(f::Function, r::ZipReader, i::Integer)
-    io = zip_openentry(r, i)
-    try
-        f(io)
-    finally
-        close(io)
     end
 end
 
@@ -723,7 +764,7 @@ function Base.show(io::IO, r::ZipBufferReader)
 end
 
 
-function zip_openentry(r::ZipBufferReader, i::Integer)
+function zip_openentry(r::ZipBufferReader, i::Int)
     entry::EntryInfo = r.entries[i]
     validate_entry(entry, length(r.buffer))
     io = IOBuffer(r.buffer)

--- a/src/reader.jl
+++ b/src/reader.jl
@@ -76,7 +76,7 @@ zip_isdir(x::HasEntries, i::Integer)::Bool = endswith(x.entries[i].name, "/")
 """
     zip_isdir(x::HasEntries, s::AbstractString)::Bool
 
-Return if any entry has a relative path starting with `s`.
+Return if `s` is an implicit or explicit directory in `x`
 """
 function zip_isdir(x::HasEntries, s::AbstractString)::Bool
     if !endswith(s,"/")

--- a/test/test_big_zips.jl
+++ b/test/test_big_zips.jl
@@ -25,7 +25,7 @@ end
     filename = tempname()
     ZipWriter(filename) do w
         zip_newfile(w, "bigfile";
-            compression_method = ZipArchives.Deflate,
+            compress=true,
             compression_level = 1,
         )
         x = zeros(UInt8,2^17)

--- a/test/test_reader.jl
+++ b/test/test_reader.jl
@@ -247,13 +247,9 @@ function rewrite_zip(old::AbstractString, new::AbstractString)
                     continue
                 end
                 isexe = zip_isexecutablefile(r, i)
-                comp = if zip_iscompressed(r, i)
-                    ZipArchives.Deflate
-                else
-                    ZipArchives.Store
-                end
+                comp = zip_iscompressed(r, i)
                 # zip_writefile(w, name, zip_readentry(r, i); executable=isexe)
-                zip_newfile(w, name; executable=isexe, compression_method= comp)
+                zip_newfile(w, name; executable=isexe, compress=comp)
                 zip_openentry(r, i) do io
                     write(w, io)
                 end

--- a/test/test_writer.jl
+++ b/test/test_writer.jl
@@ -23,21 +23,21 @@ ZipWriter(joinpath(tmp, "onefile.zip")) do w
 end
 
 ZipWriter(joinpath(tmp, "compressedfiles.zip")) do w
-    zip_newfile(w, "test1.txt"; compression_method=ZipArchives.Deflate)
+    zip_newfile(w, "test1.txt"; compress=true)
     write(w, "I am compressed data inside test1.txt in the zip file")
-    zip_newfile(w, "test2.txt"; compression_method=ZipArchives.Deflate, compression_level=9)
+    zip_newfile(w, "test2.txt"; compress=true, compression_level=9)
     write(w, "I am compressed data inside test2.txt in the zip file")
-    zip_newfile(w, "empty.txt"; compression_method=ZipArchives.Deflate, compression_level=9)
+    zip_newfile(w, "empty.txt"; compress=true, compression_level=9)
 end
 
 ZipWriter(joinpath(tmp, "different_compressed_levels.zip")) do w
-    zip_newfile(w, "default_level.txt"; compression_method=ZipArchives.Deflate)
+    zip_newfile(w, "default_level.txt"; compress=true)
     write(w, "I am compressed data inside default in the zip file")
     for level in -1:9
-        zip_newfile(w, "level_$(level).txt"; compression_method=ZipArchives.Deflate, compression_level=level)
+        zip_newfile(w, "level_$(level).txt"; compress=true, compression_level=level)
         write(w, "I am compressed data inside level_$(level).txt in the zip file")
     end
-    zip_newfile(w, "empty.txt"; compression_method=ZipArchives.Deflate, compression_level=9)
+    zip_newfile(w, "empty.txt"; compress=true, compression_level=9)
 end
 
 ZipWriter(joinpath(tmp, "twofiles.zip")) do w

--- a/test/test_writer.jl
+++ b/test/test_writer.jl
@@ -190,6 +190,10 @@ end
     r = ZipBufferReader(read(io))
     @test zip_names(r) == ["empty_dir/", "symlink_entry", "script.sh", "script2.sh", "weird thing"]
     @test zip_isdir(r, 1)
+    @test zip_isdir(r, "empty_dir/")
+    @test zip_isdir(r, "empty_dir")
+    @test !zip_isdir(r, "")
+    @test !zip_isdir(r, "/")
     @test !zip_isexecutablefile(r, 1)
 
     @test !zip_isdir(r, 2)


### PR DESCRIPTION
Replace `compression_method=ZipArchives.Deflate`  with `compress=true` when calling `zip_newfile`