### PR TITLE
Add Aqua.jl tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Build Status](https://github.com/medyan-dev/ZipArchives.jl/workflows/CI/badge.svg)](https://github.com/medyan-dev/ZipArchives.jl/actions)
 [![codecov](https://codecov.io/gh/medyan-dev/ZipArchives.jl/branch/main/graph/badge.svg?token=K3J0T9BZ42)](https://codecov.io/gh/medyan-dev/ZipArchives.jl)
+[![Aqua QA](https://raw.githubusercontent.com/JuliaTesting/Aqua.jl/master/badge.svg)](https://github.com/JuliaTesting/Aqua.jl)
 
 This package is not well tested yet.
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -81,7 +81,7 @@ struct ZipBufferReader{T<:AbstractVector{UInt8}}
 end
 
 
-Base.@kwdef mutable struct PartialEntry{S<:IO}
+Base.@kwdef mutable struct PartialEntry
     name::String
     "lowercase normalized name used to check for name collisions"
     normed_name::Union{Nothing, String}
@@ -97,7 +97,6 @@ Base.@kwdef mutable struct PartialEntry{S<:IO}
     compressed_size::UInt64 = 0
     uncompressed_size::UInt64 = 0
     local_header_size::Int64 = 50 + ncodeunits(name)
-    transcoder::Union{Nothing, NoopStream{S}, DeflateCompressorStream{S}} = nothing
 end
 
 mutable struct ZipWriter{S<:IO} <: IO
@@ -105,11 +104,12 @@ mutable struct ZipWriter{S<:IO} <: IO
     _own_io::Bool
     entries::Vector{EntryInfo}
     central_dir_buffer::Vector{UInt8}
-    partial_entry::Union{Nothing, PartialEntry{S}}
+    partial_entry::Union{Nothing, PartialEntry}
     closed::Bool
     force_zip64::Bool
     used_names_lower::Set{String}
     check_names::Bool
+    transcoder::Union{Nothing, NoopStream{S}, DeflateCompressorStream{S}}
     function ZipWriter(io::IO;
             check_names::Bool=true,
             own_io::Bool=false,
@@ -125,6 +125,7 @@ mutable struct ZipWriter{S<:IO} <: IO
             force_zip64,
             Set{String}(),
             check_names,
+            nothing,
         )
     end
 end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"
 LibArchive_jll = "1e303b3e-d4db-56ce-88c4-91e52606a1a8"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,7 @@
 using Test
 using Random
 using ZipArchives
-using Aqua
+import Aqua
 
 Aqua.test_all(ZipArchives)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,9 @@
 using Test
 using Random
 using ZipArchives
+using Aqua
+
+Aqua.test_all(ZipArchives)
 
 Random.seed!(1234)
 


### PR DESCRIPTION
Aqua didn't like the parametric type definition for `PartialEntry`, so I moved the `transcoder` field into `ZipWriter`.