### PR TITLE
Add 32 bit to CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,6 +25,9 @@ jobs:
         arch:
           - x64
           - x86
+        exclude:
+          - os: macOS-latest
+            arch: x86
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -24,6 +24,7 @@ jobs:
           - macos-latest
         arch:
           - x64
+          - x86
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/src/reader.jl
+++ b/src/reader.jl
@@ -566,7 +566,7 @@ function zip_open_filereader(filename::AbstractString)::ZipFileReader
         entries, central_dir_buffer, central_dir_offset = lock(io_lock) do
             parse_central_directory(io)
         end
-        _ref_counter = Ref(1)
+        _ref_counter = Ref(Int64(1))
         _open = Ref(true)
         fsize = lock(io_lock) do
             _ref_counter[] = 1

--- a/test/external_unzippers.jl
+++ b/test/external_unzippers.jl
@@ -6,7 +6,11 @@ import ZipFile
 import p7zip_jll
 import LibArchive_jll
 # ENV["JULIA_CONDAPKG_BACKEND"] = "Null"
-import PythonCall
+try
+    import PythonCall
+catch
+    @warn "PythonCall not working :("
+end
 
 
 
@@ -31,6 +35,10 @@ function unzip_bsdtar(zippath, dirpath)
         run(`$(exe) -x -f $(zippath) -C $(dirpath)`)
     end
     nothing
+end
+
+function have_python()
+    isdefined(@__MODULE__, :PythonCall)
 end
 
 """
@@ -75,8 +83,13 @@ end
 unzippers = Any[
     unzip_p7zip,
     unzip_bsdtar,
-    unzip_python,
 ]
+
+if have_python()
+    push!(unzippers, unzip_python)
+else
+    @info "python not found, skipping `unzip_python` tests"
+end
 
 if have_infozip()
     push!(unzippers, unzip_infozip)


### PR DESCRIPTION
Adds 32-bit systems to the CI tests.

Also adds some more explicit use `Int64`, and more careful checking for overflow.

I still need to add tests for writing and reading files larger than 4GB on 32-bit systems.